### PR TITLE
Upgrade Slimmer, stop explicitly setting 'core_layout'

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,7 @@ gem 'airbrake', '4.1.0'
 gem 'unicorn', '4.8.3'
 gem 'logstasher', '0.6.1'
 gem 'gds-api-adapters', '20.1.1'
-gem 'slimmer', '8.1.0'
+gem 'slimmer', '9.0.0'
 
 group :development, :test do
   gem 'rspec-rails', '3.1.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -120,7 +120,7 @@ GEM
       rspec-support (~> 3.1.0)
     rspec-support (3.1.2)
     safe_yaml (1.0.4)
-    slimmer (8.1.0)
+    slimmer (9.0.0)
       activesupport
       json
       nokogiri (>= 1.5.0, < 1.7.0)
@@ -161,6 +161,6 @@ DEPENDENCIES
   logstasher (= 0.6.1)
   rails (= 4.1.11)
   rspec-rails (= 3.1.0)
-  slimmer (= 8.1.0)
+  slimmer (= 9.0.0)
   unicorn (= 4.8.3)
   webmock (= 1.20.4)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,8 +1,5 @@
 class ApplicationController < ActionController::Base
-  include Slimmer::Headers
   include Slimmer::SharedTemplates
-
-  before_filter :set_slimmer_headers
 
   # Prevent CSRF attacks by raising an exception.
   # For APIs, you may want to use :null_session instead.
@@ -10,9 +7,5 @@ class ApplicationController < ActionController::Base
 
   def error_not_found
     render status: :not_found, text: "404 error not found"
-  end
-
-  def set_slimmer_headers
-    response.headers[Slimmer::Headers::TEMPLATE_HEADER] = "core_layout"
   end
 end


### PR DESCRIPTION
Note; These seems like a dead-repo, but I want to get slimmer/template setting
rolled out across all the apps.

This should be a no-op change to app behaviour. The Slimmer upgrade will cancel
out the removal of explicitly setting slimmer template.

Slimmer 9.0.0 switched to `core_layout` [1] as the default layout, which is the
modern/recommend layout. Apps using legacy layout should set it explicitly, so
they're easily identified as outliers to be fixed.

Apps using `core_layout` shouldn't set slimmer template at all, which simplies
the app controller code too.

[1] https://github.com/alphagov/slimmer/pull/136
